### PR TITLE
Add parameters to limit content in SQL dump

### DIFF
--- a/autoupgrade-scripts/upgrade.sh
+++ b/autoupgrade-scripts/upgrade.sh
@@ -209,9 +209,9 @@ dump_DB() {
   echo "--- Create dump for $1 ---"
   version="${1//./}"
    if [[ -n "$2" ]]; then
-      docker compose run --rm mysql sh -c "exec mysqldump -hmysql -uroot --no-data -p$MYSQL_ROOT_PASSWORD presta_$version" >"$DUMP_DIRECTORY"/"$1"_to_"$2"_dump_.sql
+      docker compose run --rm mysql sh -c "exec mysqldump -hmysql -uroot --no-data --compact -p$MYSQL_ROOT_PASSWORD presta_$version" | sed 's/ AUTO_INCREMENT=[0-9]*\b//g' >"$DUMP_DIRECTORY"/"$1"_to_"$2"_dump_.sql
    else
-      docker compose run --rm mysql sh -c "exec mysqldump -hmysql -uroot --no-data -p$MYSQL_ROOT_PASSWORD presta_$version" >"$DUMP_DIRECTORY"/"$1"_dump_.sql
+      docker compose run --rm mysql sh -c "exec mysqldump -hmysql -uroot --no-data --compact -p$MYSQL_ROOT_PASSWORD presta_$version" | sed 's/ AUTO_INCREMENT=[0-9]*\b//g' >"$DUMP_DIRECTORY"/"$1"_dump_.sql
    fi
   echo "--- Create dump for $1 done ---"
   echo ""


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add parameters to the SQL dump command so comments and AUTOINCREMENT are removed.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | /
| How to test?      | Run `./autoupgrade-scripts/upgrade.sh`. Then the SQL diff found in dumps should contains only relevant diff in DB.

![image](https://github.com/PrestaShop/SeamlessUpgradeToolbox/assets/6768917/3bc47dd9-07a8-4bb4-8c5c-2ba60ca67ddf)
