### PR TITLE
[FEAT] Use distribution API

### DIFF
--- a/autoupgrade-env/.env
+++ b/autoupgrade-env/.env
@@ -1,6 +1,6 @@
 # Version of prestashop
 # Ex: 1.7.8.9, 8.0.0, 8.1.5
-PRESTASHOP_VERSION=8.1.0
+PRESTASHOP_VERSION=9.0.2
 
 # If the target version is under development, set to true for build this version
 PRESTASHOP_DEVELOPMENT_VERSION=false
@@ -14,7 +14,7 @@ AUTOUPGRADE_GIT_BRANCH=dev
 BUILD_NEW_UI=true
 
 # BO location
-ADMIN_DIR=admin1234
+ADMIN_DIR=admin-dev
 # login informations
 BO_EMAIL=demo@prestashop.com
 BO_PASSWORD=toto1234

--- a/autoupgrade-rollback-scripts/.env
+++ b/autoupgrade-rollback-scripts/.env
@@ -1,9 +1,9 @@
 # Base version of prestashop
 # Ex: 1.7.8.9, 8.0.0, 8.1.5
-BASE_VERSION=8.0.5
+BASE_VERSION=8.2.1
 # Destination version of prestashop
 # Ex: 1.7.8.9, 8.0.0, 8.1.5
-UPGRADE_VERSION=8.1.7
+UPGRADE_VERSION=9.0.1
 
 # If the target version is under development, set to true for build this version
 UPGRADE_DEVELOPMENT_VERSION=false
@@ -28,7 +28,7 @@ CREATE_AND_COMPARE_DUMP_WITH_FRESH_INSTALL=false
 PERFORM_ONLY_CORE_DATABASE_UPGRADE=false
 
 # BO location
-ADMIN_DIR=admin1234
+ADMIN_DIR=admin-dev
 # login informations
 BO_EMAIL=demo@prestashop.com
 BO_PASSWORD=toto1234

--- a/autoupgrade-scripts/.env
+++ b/autoupgrade-scripts/.env
@@ -3,7 +3,7 @@
 BASE_VERSION=8.1.0
 # Destination version of prestashop
 # Ex: 1.7.8.9, 8.0.0, 8.1.5
-UPGRADE_VERSION=9.0.0
+UPGRADE_VERSION=9.0.2
 
 # If the target version is under development, set to true for build this version
 UPGRADE_DEVELOPMENT_VERSION=false
@@ -34,7 +34,7 @@ CREATE_AND_COMPARE_FILES_WITH_FRESH_INSTALL=false
 PERFORM_ONLY_CORE_DATABASE_UPGRADE=false
 
 # BO location
-ADMIN_DIR=admin1234
+ADMIN_DIR=admin-dev
 # login informations
 BO_EMAIL=demo@prestashop.com
 BO_PASSWORD=toto1234

--- a/lib/autoupgrade-lib.sh
+++ b/lib/autoupgrade-lib.sh
@@ -105,8 +105,8 @@ download_release_and_xml() {
     unzip -o prestashop_$1.zip -d $1 >/dev/null;
     rm prestashop_$1.zip;
     cd $1 || exit;
-    unzip -o prestashop.zip >/dev/null; \
-    rm prestashop.zip; \
+    unzip -o prestashop.zip >/dev/null; 
+    rm prestashop.zip; "
 
   if [ ! $? -eq 0 ]; then
     echo "Unzip v$1 Prestashop release fail"

--- a/lib/autoupgrade-lib.sh
+++ b/lib/autoupgrade-lib.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Get release data from PrestaShop API
+# Params:
+#   $1 - release version. ex: 8.0.5
+#
+get_release_data() {
+  RELEASE_DATA=$(curl -s https://api.prestashop-project.org/prestashop | jq --arg VERSION "$1" '.[] | select(.version==$VERSION)')
+  if [ -z "$RELEASE_DATA" ]; then
+    echo "Version $1 not found in Distribution API." >&2
+    return 1
+  else
+    echo "Version $1 found in Distribution API." >&2
+    echo "$RELEASE_DATA"
+  fi
+}
+
 # Download ZIP for initial install.
 # The contents of the ZIP are copied to the releases folder under the version name
 # Params:
@@ -12,11 +27,17 @@ download_release() {
     echo "Cache detected ! skip download zip"
     cp "$CACHE_DIRECTORY"/"$1".zip "$RELEASE_DIRECTORY"/prestashop_"$1".zip
   else
+    RELEASE_DATA=$(get_release_data "$1")
+    if [ $? -ne 0 ]; then
+      exit 1
+    fi
+    ZIP_URL=$(echo "$RELEASE_DATA" | jq -r '.zip_download_url')
+
     docker compose run -u "$DOCKER_USER_ID" --rm -v "$(pwd)":/var/www/html/ -w /var/www/html/"$RELEASE_DIRECTORY" work-base \
-      curl --fail -LO https://github.com/PrestaShop/zip-archives/raw/main/prestashop_"$1".zip
+      curl --fail -L "$ZIP_URL" -o prestashop_"$1".zip
 
     if [ ! $? -eq 0 ]; then
-      echo "Download v$1 Prestashop release zip fail, see" https://github.com/PrestaShop/zip-archives/raw/main/prestashop_"$1".zip
+      echo "Download v$1 Prestashop release zip fail, see $ZIP_URL"
       exit 1
     fi
     cp "$RELEASE_DIRECTORY"/prestashop_"$1".zip "$CACHE_DIRECTORY"/"$1".zip
@@ -26,9 +47,9 @@ download_release() {
     "unzip -o prestashop_$1.zip -d $1 >/dev/null;
      rm prestashop_$1.zip;
      cd $1 || exit;
-     unzip -o prestashop.zip >/dev/null;
-     rm prestashop.zip;
-     mkdir admin/autoupgrade/download;
+     unzip -o prestashop.zip >/dev/null; \
+     rm prestashop.zip; \
+     mkdir -p admin/autoupgrade/download;
      mv admin $ADMIN_DIR;
      cp -r ../$1 ../$1_base;"
 
@@ -44,15 +65,22 @@ download_release() {
 download_release_and_xml() {
   echo "--- Download v$1 Prestashop release and xml MD5 ---"
 
+  RELEASE_DATA=$(get_release_data "$1")
+  if [ $? -ne 0 ]; then
+    exit 1
+  fi
+  ZIP_URL=$(echo "$RELEASE_DATA" | jq -r '.zip_download_url')
+  XML_URL=$(echo "$RELEASE_DATA" | jq -r '.xml_download_url')
+
   if [ -e "$CACHE_DIRECTORY"/"$1".zip ]; then
     echo "Cache detected ! skip download zip"
     cp "$CACHE_DIRECTORY"/"$1".zip "$RELEASE_DIRECTORY"/"$BASE_VERSION"/"$ADMIN_DIR"/autoupgrade/download/prestashop_"$1".zip
   else
     docker compose run -u "$DOCKER_USER_ID" --rm -v "$(pwd)":/var/www/html/ -w /var/www/html/"$RELEASE_DIRECTORY"/"$BASE_VERSION" work-base \
-      curl --fail -L https://github.com/PrestaShop/zip-archives/raw/main/prestashop_"$1".zip -o "$ADMIN_DIR"/autoupgrade/download/prestashop_"$1".zip
+      curl --fail -L "$ZIP_URL" -o "$ADMIN_DIR"/autoupgrade/download/prestashop_"$1".zip
 
     if [ ! $? -eq 0 ]; then
-      echo "Download v$1 Prestashop release zip fail, see" https://github.com/PrestaShop/zip-archives/raw/main/prestashop_"$1".zip
+      echo "Download v$1 Prestashop release zip fail, see $ZIP_URL"
       exit 1
     fi
     cp "$RELEASE_DIRECTORY"/"$BASE_VERSION"/"$ADMIN_DIR"/autoupgrade/download/prestashop_"$1".zip "$CACHE_DIRECTORY"/"$1".zip
@@ -63,10 +91,10 @@ download_release_and_xml() {
     cp "$CACHE_DIRECTORY"/"$1".xml "$RELEASE_DIRECTORY"/"$BASE_VERSION"/"$ADMIN_DIR"/autoupgrade/download/prestashop_"$1".xml
   else
     docker compose run -u "$DOCKER_USER_ID" --rm -v "$(pwd)":/var/www/html/ -w /var/www/html/"$RELEASE_DIRECTORY"/"$BASE_VERSION" work-base \
-      curl --fail -L https://api.prestashop.com/xml/md5/"$1".xml -o "$ADMIN_DIR"/autoupgrade/download/prestashop_"$1".xml
+      curl --fail -L "$XML_URL" -o "$ADMIN_DIR"/autoupgrade/download/prestashop_"$1".xml
 
     if [ ! $? -eq 0 ]; then
-      echo "Download v$1 Prestashop release xml fail, see" https://api.prestashop.com/xml/md5/"$1".xml
+      echo "Download v$1 Prestashop release xml fail, see $XML_URL"
       exit 1
     fi
     cp "$RELEASE_DIRECTORY"/"$BASE_VERSION"/"$ADMIN_DIR"/autoupgrade/download/prestashop_"$1".xml "$CACHE_DIRECTORY"/"$1".xml
@@ -77,8 +105,8 @@ download_release_and_xml() {
     unzip -o prestashop_$1.zip -d $1 >/dev/null;
     rm prestashop_$1.zip;
     cd $1 || exit;
-    unzip -o prestashop.zip >/dev/null;
-    rm prestashop.zip;"
+    unzip -o prestashop.zip >/dev/null; \
+    rm prestashop.zip; \
 
   if [ ! $? -eq 0 ]; then
     echo "Unzip v$1 Prestashop release fail"


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Use distribution API inside [lib/autoupgrade-lib.sh](https://github.com/PrestaShop/SeamlessUpgradeToolbox/lib/autoupgrade-lib.sh) instead of using GitHub release because Prestashop 9+ are not anymore published on GitHub.
| Type?             | improvement
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | Try the tools with PrestaShop > 9
